### PR TITLE
fix: allow cli option to set npm client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           command: yarn ci-check
 
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
 
       - run:
           name: Run end-to-end tests

--- a/packages/cli-runtime/src/plugins/create/create.js
+++ b/packages/cli-runtime/src/plugins/create/create.js
@@ -18,13 +18,11 @@ const which = util.promisify(npmWhich);
  * Create a toolkit project with the given name and options.
  */
 async function create(name, options, api, env) {
-  // Grab the cwd and npmClient off of the environment. We can use these to
-  // create the folder for the project and for determining what client to use
-  // for npm-related commands
-  const { CLI_ENV, cwd, npmClient } = env;
+  const { CLI_ENV, cwd } = env;
   // We support a couple of options for our `create` command, some only exist
   // during development (like link and linkCli).
-  const { link, linkCli, plugins = [], presets = [], skip } = options;
+  const { link, linkCli, npmClient, plugins = [], presets = [], skip } = options;
+
   const root = path.join(cwd, name);
 
   logger.trace('Creating project:', name, 'at:', root);


### PR DESCRIPTION
It looks like the `npmClient` option for the `create` plugin wasn't getting passed down.

(As far as I could tell, the `npmClient` for the environment gets set based on which flavor of lockfile you have, which presumably wouldn't be there during this step)

#### Changelog

**Changed**

- set NPM client during create step based on the CLI argument
